### PR TITLE
CompatHelper: inherit secrets in reusable caller

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -12,3 +12,4 @@ jobs:
     uses: "ITensor/ITensorActions/.github/workflows/CompatHelper.yml@main"
     with:
       localregistry: "https://github.com/ITensor/ITensorRegistry.git"
+    secrets: "inherit"


### PR DESCRIPTION
## Summary
- add `secrets: "inherit"` to `.github/workflows/CompatHelper.yml`
- keep workflow behavior unchanged otherwise

## Why
This lets the reusable CompatHelper workflow receive `COMPATHELPER_PAT` when available, so token-owner detection uses the PAT owner path (ITensorBot) instead of falling back to the GitHub App token path.

## Scope
- minimal one-line workflow caller patch
- prep step so repos are in a common state ahead of the broader security-workflow rollout