### PR TITLE
Skip Aqua persistent_tasks check

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ITensorUnicodePlots"
 uuid = "73163f41-4a9e-479f-8353-73bf94dbd758"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Matthew Fishman <mfishman@flatironinstitute.org> and contributors"]
 
 [workspace]

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -3,5 +3,9 @@ using ITensorUnicodePlots: ITensorUnicodePlots
 using Test: @testset
 
 @testset "Code quality (Aqua.jl)" begin
-    Aqua.test_all(ITensorUnicodePlots)
+    # `persistent_tasks=false` skips Aqua's persistent-tasks subprocess check,
+    # which misreports precompile-cache mismatches as task leaks
+    # (https://github.com/JuliaTesting/Aqua.jl/issues/315) and has been flaking
+    # under integration-test resolves that re-precompile many transitive deps.
+    Aqua.test_all(ITensorUnicodePlots; persistent_tasks = false)
 end

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -3,9 +3,5 @@ using ITensorUnicodePlots: ITensorUnicodePlots
 using Test: @testset
 
 @testset "Code quality (Aqua.jl)" begin
-    # `persistent_tasks=false` skips Aqua's persistent-tasks subprocess check,
-    # which misreports precompile-cache mismatches as task leaks
-    # (https://github.com/JuliaTesting/Aqua.jl/issues/315) and has been flaking
-    # under integration-test resolves that re-precompile many transitive deps.
     Aqua.test_all(ITensorUnicodePlots; persistent_tasks = false)
 end


### PR DESCRIPTION
## Summary

- Pass `persistent_tasks=false` to `Aqua.test_all` in `test/test_aqua.jl`. The rest of the Aqua suite keeps running.
- Aqua's `test_persistent_tasks` spawns a child Julia subprocess; if precompilation in that subprocess exits before writing the done-marker, the test fails with a misleading "persistent tasks" message instead of surfacing the underlying precompile error. Tracked upstream at [JuliaTesting/Aqua.jl#315](https://github.com/JuliaTesting/Aqua.jl/issues/315), open since April 2025.
- The check has been flaking on `IntegrationTest` runs against downstream consumers: `Pkg.develop`'ing a dev'd version of an upstream dep triggers a divergent re-resolve where ~100+ transitive deps end up with "different versions currently loaded", and Aqua's subprocess precompile then fails to converge.